### PR TITLE
add ordering puzzles to the RL training pipeline

### DIFF
--- a/examples/data_preprocess/gen_proof.py
+++ b/examples/data_preprocess/gen_proof.py
@@ -1,0 +1,755 @@
+from puzzle_gen import Constraint
+import os
+from typing import List, Set, Dict, Tuple, Optional
+import re
+from dataclasses import dataclass, field
+from copy import deepcopy
+import random
+import sys
+import pdb
+import signal
+import time
+from contextlib import contextmanager
+
+DEBUG = False
+
+@dataclass
+class SearchNode:
+    """Data class to represent a search node in the tree."""
+    depth: int
+    arrangement: Dict[str, int] = field(default_factory=dict)
+    satisfied_constraints: Set[int] = field(default_factory=set)
+    children: List['SearchNode'] = field(default_factory=list)
+    is_leaf: bool = False
+    parent: Optional['SearchNode'] = None
+    
+
+    def __str__(self):
+        positions = [-1] * len(self.arrangement)
+        for bird, pos in self.arrangement.items():
+            if pos != -1:
+                positions[pos] = bird
+        return f"Arrangement: {positions}, Satisfied: {self.satisfied_constraints}"
+
+class PuzzleSolver:
+    def __init__(self, birds: List[str], puzzle_constraints: List[str]=None):
+        self.birds = birds
+        self.num_positions = len(birds)
+        self.raw_constraints = puzzle_constraints
+        self.constraints: List[Constraint] = []
+        self.absolute_constraints: List[Constraint] = []
+        self.relative_constraints: List[Constraint] = []
+        self.steps: List[str] = []
+        self.ground_truth: List[str] = []
+        
+    
+    def add_step(self, step: str):
+        """Add a step to the list of reasoning steps."""
+        self.steps.append(step)
+        # print(step)
+
+
+
+    def parse_constraints(self):
+        """Parse text constraints into structured Constraint objects."""
+        for text in self.raw_constraints:
+            constraint = self._parse_single_constraint(text)
+            self.constraints.append(constraint)
+            
+            # Separate absolute and relative constraints
+            if constraint.constraint_type in ['absolute_position_left', 'absolute_position_right']:
+                self.absolute_constraints.append(constraint)
+            else:
+                self.relative_constraints.append(constraint)
+    
+    def _parse_single_constraint(self, text:str)->Constraint:
+        """Parse a single text constraint into a Constraint object."""
+        # Pattern for extracting bird names
+        bird_pattern = '|'.join(self.birds)
+        # Absolute position patterns
+        if "from the left" in text or "from the right" in text:
+            match = re.search(rf"The ({bird_pattern}) is the (\d+)[a-z]+ from the (left|right)", text)
+            if match:
+                bird, position, direction = match.groups()
+                return Constraint(
+                    text=text,
+                    bird1=bird,
+                    bird2=None,
+                    constraint_type=f"absolute_position_{direction}",
+                    value=int(position)
+                )
+        
+        # Birds between pattern
+        if "bird" in text and "between" in text:
+            match = re.search(rf"There (?:is|are) (\d+) birds? between the ({bird_pattern}) and the ({bird_pattern})", text)
+            if match:
+                num_birds, bird1, bird2 = match.groups()
+                return Constraint(
+                    text=text,
+                    bird1=bird1,
+                    bird2=bird2,
+                    constraint_type="birds_between",
+                    value=int(num_birds)
+                )
+        
+        # Immediately adjacent patterns
+        if "immediately" in text:
+            if "to the left of" in text:
+                match = re.search(f"The ({bird_pattern}) is immediately to the left of the ({bird_pattern})", text)
+                bird1, bird2 = match.groups()
+                return Constraint(
+                    text=text,
+                    bird1=bird1,
+                    bird2=bird2,
+                    constraint_type="adjacent_left",
+                    value=None
+                )
+            elif "to the right of" in text:
+                match = re.search(f"The ({bird_pattern}) is immediately to the right of the ({bird_pattern})", text)
+                bird1, bird2 = match.groups()
+                return Constraint(
+                    text=text,
+                    bird1=bird1,
+                    bird2=bird2,
+                    constraint_type="adjacent_right",
+                    value=None
+                )
+        
+        # General left/right patterns
+        if "to the left of" in text:
+            match = re.search(f"The ({bird_pattern}) is to the left of the ({bird_pattern})", text)
+            bird1, bird2 = match.groups()
+            return Constraint(
+                text=text,
+                bird1=bird1,
+                bird2=bird2,
+                constraint_type="left_of",
+                value=None
+            )
+        elif "to the right of" in text:
+            match = re.search(f"The ({bird_pattern}) is to the right of the ({bird_pattern})", text)
+            bird1, bird2 = match.groups()
+            return Constraint(
+                text=text,
+                bird1=bird1,
+                bird2=bird2,
+                constraint_type="right_of",
+                value=None
+            )
+        
+        raise ValueError(f"Could not parse constraint: {text}")
+    
+
+
+        
+    def init_helper(self, file_path: str):
+        """Initialize the solver with the puzzle file."""
+        self.ground_truth = self.read_file(file_path)
+        self.birds = random.shuffle(self.ground_truth)# Shuffle the birds
+        self.parse_constraints()
+
+    def verify_constraint(self, arrangement: Dict[str, int], constraint: Constraint) -> bool:
+        """Check if a single constraint is satisfied by current arrangement"""
+        """Return true only if the constraint is satisfied else false"""
+        if constraint.constraint_type == "absolute_position_left":
+            pos = arrangement.get(constraint.bird1, -1)
+            return pos == constraint.value - 1
+            
+        elif constraint.constraint_type == "absolute_position_right":
+            pos = arrangement.get(constraint.bird1, -1)
+            return pos == self.num_positions - constraint.value if pos != -1 else False
+            
+        elif constraint.constraint_type == "adjacent_left":
+            pos1 = arrangement.get(constraint.bird1, -1)
+            pos2 = arrangement.get(constraint.bird2, -1)
+            return pos1 != -1 and pos2 != -1 and pos1 + 1 == pos2
+            
+        elif constraint.constraint_type == "adjacent_right":
+            pos1 = arrangement.get(constraint.bird1, -1)
+            pos2 = arrangement.get(constraint.bird2, -1)
+            return pos1 != -1 and pos2 != -1 and pos1 - 1 == pos2
+            
+        elif constraint.constraint_type == "birds_between":
+            pos1 = arrangement.get(constraint.bird1, -1)
+            pos2 = arrangement.get(constraint.bird2, -1)
+            if pos1 != -1 and pos2 != -1:
+                return abs(pos1 - pos2) - 1 == constraint.value
+            return False  # Can't verify yet
+            
+        elif constraint.constraint_type == "left_of":
+            pos1 = arrangement.get(constraint.bird1, -1)
+            pos2 = arrangement.get(constraint.bird2, -1)
+            return pos1 < pos2 if pos1 != -1 and pos2 != -1 else False
+            
+        elif constraint.constraint_type == "right_of":
+            pos1 = arrangement.get(constraint.bird1, -1)
+            pos2 = arrangement.get(constraint.bird2, -1)
+            return pos1 > pos2 if pos1 != -1 and pos2 != -1 else False
+            
+        return False
+    
+    def solve(self) -> Optional[Dict[str, int]]:
+        """Main solving function"""
+        # Parse constraints if not done already
+        if not self.constraints:
+            self.parse_constraints()
+            
+        # Start with empty arrangement
+        initial_arrangement = {bird: -1 for bird in self.birds}
+        # First apply absolute constraints
+        self.add_step("Starting with absolute position constraints:")
+        for i, constraint in enumerate(self.absolute_constraints):
+            bird = constraint.bird1
+            if constraint.constraint_type == "absolute_position_left":
+                initial_arrangement[bird] = constraint.value - 1
+                self.add_step(f"Placing {bird} at position {constraint.value} from left")
+            else:  # absolute_position_right
+                pos = self.num_positions - constraint.value
+                initial_arrangement[bird] = pos
+                self.add_step(f"Placing {bird} at position {pos + 1} from left ({constraint.value} from right)")
+        
+        # Create initial node
+        initial_node = SearchNode(
+            arrangement=initial_arrangement,
+            satisfied_constraints=set(),
+            depth=0
+        )
+        
+        # Start Tree Search
+        self.add_step("Starting search to find complete arrangement...")
+        result = self.dfs(initial_node)
+        
+        if result:
+            positions = [-1] * self.num_positions
+            for bird, pos in result.arrangement.items():
+                positions[pos] = bird
+            if -1 in positions:
+                index = positions.index(-1)
+                positions[index] = [bird for bird in self.birds if bird not in positions][0]
+                self.add_step(f"{positions[index]} is placed at position {index} since only one spot was left")
+            self.add_step("Found solution!")
+            self.add_step(f"Final arrangement: {positions}")
+            return result.arrangement
+        else:
+            self.add_step("\nNo solution found!")
+            return None
+        
+    def dfs(self, node: SearchNode) -> Optional[SearchNode]:
+        """Depth-first search implementation"""
+        # First verify all constraints are satisfied for current arrangement
+        if DEBUG:
+            pdb.set_trace()
+            print(f"\nDEBUG: Current depth: {node.depth}")
+            print(f"DEBUG: Current arrangement: {node.arrangement}")
+            print(f"DEBUG: Satisfied constraints: {node.satisfied_constraints}")
+        violated_constraint = None
+        current_constraint = None
+        current_constraint_index = None
+        for i, constraint in enumerate(self.relative_constraints):
+            if i not in node.satisfied_constraints:
+                consistent = self.verify_constraint(node.arrangement, constraint)
+                if consistent:
+                    node.satisfied_constraints.add(i)
+                else:
+                    current_constraint = constraint
+                    current_constraint_index = i
+                    break
+        
+        # return if solution found
+        if not current_constraint:
+            if DEBUG: print("DEBUG: No more constraints to satisfy!")
+            node.is_leaf = True
+            return node
+        
+        filled = set(pos for pos in node.arrangement.values() if pos != -1)
+        empty_positions = sorted(set(range(self.num_positions)) - filled)
+        if DEBUG: print(f"DEBUG: Empty positions: {empty_positions}")
+        # empty_positions = [i for bird, i in node.arrangement.items() if i == -1]
+        # import pdb; pdb.set_trace()
+        k = len(empty_positions)
+        if k==0 and current_constraint:
+            if DEBUG: print("DEBUG: No empty positions left but constraints remain!")
+            return None
+        current_arrangement = ["_"] * self.num_positions
+        for bird, pos in node.arrangement.items():
+            if pos != -1:
+                current_arrangement[pos] = bird
+
+        if current_constraint:
+            if current_constraint.constraint_type == "left_of":
+                if DEBUG: pdb.set_trace()
+                bird1 = current_constraint.bird1
+                bird2 = current_constraint.bird2
+                pos1 = node.arrangement.get(bird1, -1)
+                pos2 = node.arrangement.get(bird2, -1)
+                if pos1 != -1 and pos2 != -1 and pos1 >= pos2:
+                    violated_constraint = current_constraint
+                    self.add_step(f"Current arrangement: {current_arrangement}; Constraint violated: {current_constraint.text}, cannot proceed on this path")
+                    return None
+                elif pos1 ==-1 and pos2 == -1:
+                    for i in range(k-1):
+                        for j in range(i+1, k):
+                            new_node = deepcopy(node)
+                            new_node.arrangement[bird1] = empty_positions[i]
+                            new_node.arrangement[bird2] = empty_positions[j]
+                            new_node.satisfied_constraints.add(current_constraint_index)
+                            new_node.depth += 1
+                            new_node.parent = node
+                            node.children.append(new_node)
+                            self.add_step(f"Current arrangement: {current_arrangement}; Trying to place {bird1} to the left of {bird2} at positions {empty_positions[i]} and {empty_positions[j]}")
+                            result = self.dfs(new_node)
+                            if result:
+                                return result
+                            else:
+                                self.add_step(f"Current arrangement: {current_arrangement}; Cannot place {bird1} to the left of {bird2} at positions {empty_positions[i]} and {empty_positions[j]}")
+                else:
+                    if pos1 == -1:
+                        for i in range(k):
+                            if empty_positions[i] < pos2:
+                                new_node = deepcopy(node)
+                                new_node.arrangement[bird1] = empty_positions[i]
+                                new_node.satisfied_constraints.add(current_constraint_index)
+                                new_node.depth += 1
+                                new_node.parent = node
+                                node.children.append(new_node)
+                                self.add_step(f"Current arrangement: {current_arrangement}; Trying to place {bird1} to the left of {bird2} at positions {empty_positions[i]}")
+                                result = self.dfs(new_node)
+                                if result:
+                                    return result
+                                else:
+                                    self.add_step(f"Current arrangement: {current_arrangement}; Cannot place {bird1} to the left of {bird2} at positions {empty_positions[i]}")
+                    elif pos2 == -1:
+                        for i in range(k):
+                            if empty_positions[i] > pos1:
+                                new_node = deepcopy(node)
+                                new_node.arrangement[bird2] = empty_positions[i]
+                                new_node.satisfied_constraints.add(current_constraint_index)
+                                new_node.depth += 1
+                                new_node.parent = node
+                                node.children.append(new_node)
+                                self.add_step(f"Current arrangement: {current_arrangement}; Trying to place {bird2} to the right of {bird1} at positions {empty_positions[i]}")
+                                result = self.dfs(new_node)
+                                if result:
+                                    return result
+                                else:
+                                    self.add_step(f"Current arrangement: {current_arrangement}; Cannot place {bird2} to the right of {bird1} at positions {empty_positions[i]}")
+            elif current_constraint.constraint_type == "right_of":
+                if DEBUG: pdb.set_trace()
+                bird1 = current_constraint.bird1
+                bird2 = current_constraint.bird2
+                pos1 = node.arrangement.get(bird1, -1)
+                pos2 = node.arrangement.get(bird2, -1)
+                if pos1 != -1 and pos2 != -1 and pos1 <= pos2:
+                    violated_constraint = current_constraint
+                    self.add_step(f"Current arrangement: {current_arrangement}; Constraint violated: {current_constraint.text}, cannot proceed on this path")
+                    return None
+                elif pos1 == -1 and pos2 == -1:
+                    for i in range(k-1):
+                        for j in range(i+1, k):
+                            new_node = deepcopy(node)
+                            new_node.arrangement[bird1] = empty_positions[j]
+                            new_node.arrangement[bird2] = empty_positions[i]
+                            new_node.satisfied_constraints.add(current_constraint_index)
+                            new_node.depth += 1
+                            new_node.parent = node
+                            node.children.append(new_node)
+                            self.add_step(f"Current arrangement: {current_arrangement}; Trying to place {bird1} to the right of {bird2} at positions {empty_positions[j]} and {empty_positions[i]}")
+                            result = self.dfs(new_node)
+                            if result:
+                                return result
+                            else:
+                                self.add_step(f"Current arrangement: {current_arrangement}; Cannot place {bird1} to the right of {bird2} at positions {empty_positions[j]} and {empty_positions[i]}")
+                else:
+                    if pos1 == -1:
+                        for i in range(k):
+                            if empty_positions[i] > pos2:
+                                new_node = deepcopy(node)
+                                new_node.arrangement[bird1] = empty_positions[i]
+                                new_node.satisfied_constraints.add(current_constraint_index)
+                                new_node.depth += 1
+                                new_node.parent = node
+                                node.children.append(new_node)
+                                self.add_step(f"Current arrangement: {current_arrangement}; Trying to place {bird1} to the right of {bird2} at positions {empty_positions[i]}")
+                                result = self.dfs(new_node)
+                                if result:
+                                    return result
+                                else:
+                                    self.add_step(f"Current arrangement: {current_arrangement}; Cannot place {bird1} to the right of {bird2} at positions {empty_positions[i]}")
+                    elif pos2 == -1:
+                        for i in range(k):
+                            if empty_positions[i] < pos1:
+                                new_node = deepcopy(node)
+                                new_node.arrangement[bird2] = empty_positions[i]
+                                new_node.satisfied_constraints.add(current_constraint_index)
+                                new_node.depth += 1
+                                new_node.parent = node
+                                node.children.append(new_node)
+                                self.add_step(f"Current arrangement: {current_arrangement}; Trying to place {bird2} to the left of {bird1} at positions {empty_positions[i]}")
+                                result = self.dfs(new_node)
+                                if result:
+                                    return result
+                                else:
+                                    self.add_step(f"Current arrangement: {current_arrangement}; Cannot place {bird2} to the left of {bird1} at positions {empty_positions[i]}")
+            elif current_constraint.constraint_type == "adjacent_left":
+                if DEBUG: pdb.set_trace()
+                bird1 = current_constraint.bird1
+                bird2 = current_constraint.bird2
+                pos1 = node.arrangement.get(bird1, -1)
+                pos2 = node.arrangement.get(bird2, -1)
+                if pos1 != -1 and pos2 != -1 and pos1 + 1 != pos2:
+                    violated_constraint = current_constraint
+                    self.add_step(f"Current arrangement: {current_arrangement}; Constraint violated: {current_constraint.text}, cannot proceed on this path")
+                    return None
+                elif pos1 == -1 and pos2 == -1:
+                    for i in range(k-1):
+                        for j in range(i+1, k):
+                            if empty_positions[i] + 1 == empty_positions[j]:
+                                new_node = deepcopy(node)
+                                new_node.arrangement[bird1] = empty_positions[i]
+                                new_node.arrangement[bird2] = empty_positions[j]
+                                new_node.satisfied_constraints.add(current_constraint_index)
+                                new_node.depth += 1
+                                new_node.parent = node
+                                node.children.append(new_node)
+                                self.add_step(f"Current arrangement: {current_arrangement}; Trying to place {bird1} immediately to the left of {bird2} at positions {empty_positions[i]} and {empty_positions[j]}")
+                                result = self.dfs(new_node)
+                                if result:
+                                    return result
+                                else:
+                                    self.add_step(f"Current arrangement: {current_arrangement}; Cannot place {bird1} immediately to the left of {bird2} at positions {empty_positions[i]} and {empty_positions[j]}")
+                else:
+                    if pos1 == -1:
+                        if pos2-1 not in empty_positions:
+                            self.add_step(f"Current arrangement: {current_arrangement}; Cannot place {bird1} immediately to the left of {bird2} at positions {pos2-1}")
+                            return None
+                        new_node = deepcopy(node)
+                        new_node.arrangement[bird1] = pos2 - 1
+                        new_node.satisfied_constraints.add(current_constraint_index)
+                        new_node.depth += 1
+                        new_node.parent = node
+                        node.children.append(new_node)
+                        self.add_step(f"Current arrangement: {current_arrangement}; Trying to place {bird1} immediately to the left of {bird2} at positions {pos2-1}")
+                        result = self.dfs(new_node)
+                        if result:
+                            return result
+                        else:
+                            self.add_step(f"Current arrangement: {current_arrangement}; Cannot place {bird1} immediately to the left of {bird2} at positions {pos2-1}")
+                    elif pos2 == -1:
+                        if pos1+1 not in empty_positions:
+                            self.add_step(f"Current arrangement: {current_arrangement}; Cannot place {bird1} immediately to the left of {bird2} at positions {pos1+1}")
+                            return None
+                        new_node = deepcopy(node)
+                        new_node.arrangement[bird2] = pos1 + 1
+                        new_node.satisfied_constraints.add(current_constraint_index)
+                        new_node.depth += 1
+                        new_node.parent = node
+                        node.children.append(new_node)
+                        self.add_step(f"Current arrangement: {current_arrangement}; Trying to place {bird2} immediately to the right of {bird1} at positions {pos1+1}")
+                        result = self.dfs(new_node)
+                        if result:
+                            return result
+                        else:
+                            self.add_step(f"Current arrangement: {current_arrangement}; Cannot place {bird2} immediately to the right of {bird1} at positions {pos1+1}")
+            elif current_constraint.constraint_type == "adjacent_right":
+                if DEBUG: pdb.set_trace()
+                bird1 = current_constraint.bird1
+                bird2 = current_constraint.bird2
+                pos1 = node.arrangement.get(bird1, -1)
+                pos2 = node.arrangement.get(bird2, -1)
+                if pos1 != -1 and pos2 != -1 and pos1 - 1 != pos2:
+                    violated_constraint = current_constraint
+                    self.add_step(f"Current arrangement: {current_arrangement}; Constraint violated: {current_constraint.text}, cannot proceed on this path ")
+                    return None
+                elif pos1 == -1 and pos2 == -1:
+                    for i in range(k-1):
+                        for j in range(i+1, k):
+                            if empty_positions[i] + 1 == empty_positions[j]:
+                                new_node = deepcopy(node)
+                                new_node.arrangement[bird1] = empty_positions[j]
+                                new_node.arrangement[bird2] = empty_positions[i]
+                                new_node.satisfied_constraints.add(current_constraint_index)
+                                new_node.depth += 1
+                                new_node.parent = node
+                                node.children.append(new_node)
+                                self.add_step(f"Current arrangement: {current_arrangement}; Trying to place {bird1} immediately to the right of {bird2} at positions {empty_positions[j]} and {empty_positions[i]}")
+                                result = self.dfs(new_node)
+                                if result:
+                                    return result
+                                else:
+                                    self.add_step(f"Current arrangement: {current_arrangement}; Cannot place {bird1} immediately to the right of {bird2} at positions {empty_positions[j]} and {empty_positions[i]}")
+                else:
+                    if pos1 == -1:
+                        if pos2+1 not in empty_positions:
+                            self.add_step(f"Current arrangement: {current_arrangement}; Cannot place {bird1} immediately to the right of {bird2} at positions {pos2+1}")
+                            return None
+                        new_node = deepcopy(node)
+                        new_node.arrangement[bird1] = pos2 + 1
+                        new_node.satisfied_constraints.add(current_constraint_index)
+                        new_node.depth += 1
+                        new_node.parent = node
+                        node.children.append(new_node)
+                        self.add_step(f"Current arrangement: {current_arrangement}; Trying to place {bird1} immediately to the right of {bird2} at positions {pos2+1}")
+                        result = self.dfs(new_node)
+                        if result:
+                            return result
+                        else:
+                            self.add_step(f"Current arrangement: {current_arrangement}; Cannot place {bird1} immediately to the right of {bird2} at positions {pos2+1}")
+                    elif pos2 == -1:
+                        if pos1-1 not in empty_positions:
+                            self.add_step(f"Current arrangement: {current_arrangement}; Cannot place {bird1} immediately to the right of {bird2} at positions {pos1-1}")
+                            return None
+                        new_node = deepcopy(node)
+                        new_node.arrangement[bird2] = pos1 - 1
+                        new_node.satisfied_constraints.add(current_constraint_index)
+                        new_node.depth += 1
+                        new_node.parent = node
+                        node.children.append(new_node)
+                        self.add_step(f"Current arrangement: {current_arrangement}; Trying to place {bird2} immediately to the left of {bird1} at positions {pos1-1}")
+                        result = self.dfs(new_node)
+                        if result:
+                            return result
+                        else:
+                            self.add_step(f"Current arrangement: {current_arrangement}; Cannot place {bird2} immediately to the left of {bird1} at positions {pos1-1}")
+            elif current_constraint.constraint_type == "birds_between":
+                if DEBUG: pdb.set_trace()
+                bird1 = current_constraint.bird1
+                bird2 = current_constraint.bird2
+                pos1 = node.arrangement.get(bird1, -1)
+                pos2 = node.arrangement.get(bird2, -1)
+                value = current_constraint.value
+                if pos1 != -1 and pos2 != -1 and abs(pos1 - pos2) - 1 != value:
+                    violated_constraint = current_constraint
+                    self.add_step(f"Current arrangement: {current_arrangement}; Constraint violated: {current_constraint.text}, cannot proceed on this path")
+                    return None
+                elif pos1 == -1 and pos2 == -1:
+                    for p1 in empty_positions:
+                        for p2 in empty_positions:
+                            if p1 != p2 and abs(p1-p2) - 1 == value:
+                                # 2 paths bird 1 left of bird 2 and bird 1 right of bird 2
+                                new_node = deepcopy(node)
+                                new_node.arrangement[bird1] = p1
+                                new_node.arrangement[bird2] = p2
+                                new_node.satisfied_constraints.add(current_constraint_index)
+                                new_node.depth += 1
+                                new_node.parent = node
+                                node.children.append(new_node)
+                                self.add_step(f"Current arrangement: {current_arrangement}; Trying to place {bird1} to the left of {bird2} at positions {p1} and {p2}")
+                                result = self.dfs(new_node)
+                                if result:
+                                    return result
+                                else:
+                                    self.add_step(f"Current arrangement: {current_arrangement}; Cannot place {bird1} to the left of {bird2} at positions {p1} and {p2}")
+                                    new_node = deepcopy(node)
+                                    new_node.arrangement[bird1] = p2
+                                    new_node.arrangement[bird2] = p1
+                                    new_node.satisfied_constraints.add(current_constraint_index)
+                                    new_node.depth += 1
+                                    new_node.parent = node
+                                    node.children.append(new_node)
+                                    self.add_step(f"Current arrangement: {current_arrangement}; Trying to place {bird1} to the right of {bird2} at positions {p2} and {p1}")
+                                    result = self.dfs(new_node)
+                                    if result:
+                                        return result
+                                    else:
+                                        self.add_step(f"Current arrangement: {current_arrangement}; Cannot place {bird1} to the right of {bird2} at positions {p2} and {p1}")
+                else:
+                    if pos1 == -1:
+                        if pos2 - value - 1 in empty_positions:
+                            new_node = deepcopy(node)
+                            new_node.arrangement[bird1] = pos2 - value - 1
+                            new_node.satisfied_constraints.add(current_constraint_index)
+                            new_node.depth += 1
+                            new_node.parent = node
+                            node.children.append(new_node)
+                            self.add_step(f"Current arrangement: {current_arrangement}; Trying to place {bird1} to the left of {bird2} at positions {pos2 - value - 1}")
+                            result = self.dfs(new_node)
+                            if result:
+                                return result
+                            else:
+                                self.add_step(f"Current arrangement: {current_arrangement}; Cannot place {bird1} to the left of {bird2} at positions {pos2 - value - 1}")
+                        if pos2 + value +1 in empty_positions:
+                            new_node = deepcopy(node)
+                            new_node.arrangement[bird1] = pos2 + value + 1
+                            new_node.satisfied_constraints.add(current_constraint_index)
+                            new_node.depth += 1
+                            new_node.parent = node
+                            node.children.append(new_node)
+                            self.add_step(f"Current arrangement: {current_arrangement}; Trying to place {bird1} to the right of {bird2} at positions {pos2 + value + 1}")
+                            result = self.dfs(new_node)
+                            if result:
+                                return result
+                            else:
+                                self.add_step(f"Current arrangement: {current_arrangement}; Cannot place {bird1} to the right of {bird2} at positions {pos2 + value + 1}")
+                        else:
+                            return None
+                    elif pos2 == -1:
+                        if DEBUG: pdb.set_trace()
+                        if pos1 - value - 1 in empty_positions:
+                            new_node = deepcopy(node)
+                            new_node.arrangement[bird2] = pos1 - value - 1
+                            new_node.satisfied_constraints.add(current_constraint_index)
+                            new_node.depth += 1
+                            new_node.parent = node
+                            node.children.append(new_node)
+                            self.add_step(f"Current arrangement: {current_arrangement}; Trying to place {bird2} to the left of {bird1} at positions {pos1 - value - 1}")
+                            result = self.dfs(new_node)
+                            if result:
+                                return result
+                            else:
+                                self.add_step(f"Current arrangement: {current_arrangement}; Cannot place {bird2} to the left of {bird1} at positions {pos1 - value - 1}")
+                        if pos1 + value + 1 in empty_positions:
+                            new_node = deepcopy(node)
+                            new_node.arrangement[bird2] = pos1 + value + 1
+                            new_node.satisfied_constraints.add(current_constraint_index)
+                            new_node.depth += 1
+                            new_node.parent = node
+                            node.children.append(new_node)
+                            self.add_step(f"Current arrangement: {current_arrangement}; Trying to place {bird2} to the right of {bird1} at positions {pos1 + value + 1}")
+                            result = self.dfs(new_node)
+                            if result:
+                                return result
+                            else:
+                                self.add_step(f"Current arrangement: {current_arrangement}; Cannot place {bird2} to the right of {bird1} at positions {pos1 + value + 1}")
+                        else:
+                            return None
+        return None
+
+
+
+def read_file(file_path: str) -> List[str]:
+    """Read the puzzle file and extract the ground truth and statements."""
+    with open(file_path, 'r') as file:
+        lines = file.readlines()
+    
+    constraints = []
+
+    for line in lines:
+        if line[0].isdigit():
+            match = re.match(r"\d+\.\s*(.+)", line.strip())
+            constraints.append(match.group(1))
+    # Extract ground truth and statements
+    start = lines[0].index("[")
+    ground_truth = lines[0][start:].strip().strip("[]").split(", ")
+    ground_truth = [item.strip("'") for item in ground_truth]
+    raw_constraints = constraints
+    return ground_truth, raw_constraints
+
+class TimeoutException(Exception):
+    pass
+
+@contextmanager
+def time_limit(seconds):
+    """Context manager for timeout"""
+    def signal_handler(signum, frame):
+        raise TimeoutException("Solution took too long!")
+    
+    # Register signal handler
+    signal.signal(signal.SIGALRM, signal_handler)
+    signal.alarm(seconds)  # Start timer
+    
+    try:
+        yield
+    finally:
+        signal.alarm(0)  # Disable timer
+
+def solve_with_timeout(solver: PuzzleSolver, timeout_seconds: int) -> Optional[Dict[str, int]]:
+    """Wrapper to call solve() with timeout"""
+    try:
+        with time_limit(timeout_seconds):
+            return solver.solve()
+    except TimeoutException:
+        print(f"Solver timed out after {timeout_seconds} seconds!")
+        return None
+
+def solve_all_puzzles(num_puzzles: int):
+    random.seed(0)
+    timeout_seconds = 30  # Set timeout to 30 seconds
+    
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+    output_folder = os.path.join(base_dir, "QA_sols")
+    if not os.path.exists(output_folder):
+        os.makedirs(output_folder)
+    
+    num_sols = 0
+    num_timeouts = 0
+    
+    for i in range(num_puzzles):
+        # filepath = f"generated_QAs/birds_{i}.txt"
+        
+        try:
+            # ground_truth, raw_constraints = read_file(filepath)
+            
+            # if len(ground_truth) <= 7:
+            print(f"Solving puzzle {i}, num_sols: {num_sols}")
+            birds = deepcopy(ground_truth)
+            random.shuffle(birds)
+            sol_file = os.path.join(output_folder, f"sol_{i}.txt")
+            
+            try:
+                with open(sol_file, 'w') as file:
+                    sys.stdout = file
+                    solver = PuzzleSolver(birds=birds, puzzle_constraints=raw_constraints)
+                    solver.parse_constraints()
+                    
+                    start_time = time.time()
+                    final_arrangement = solve_with_timeout(solver, timeout_seconds)
+                    solve_time = time.time() - start_time
+                    
+                    if final_arrangement:
+                        # print(f"Solution found in {solve_time:.2f} seconds.")
+                        num_sols += 1
+                    else:
+                        # print(f"No solution found or timed out after {solve_time:.2f} seconds.")
+                        if solve_time >= timeout_seconds:
+                            num_timeouts += 1
+                            # Delete the solution file for timed out puzzles
+                            sys.stdout = sys.__stdout__
+                            os.remove(sol_file)
+                            continue
+                        
+            except Exception as e:
+                print(f"Error solving puzzle {i}: {str(e)}")
+            finally:
+                sys.stdout = sys.__stdout__
+                
+        except Exception as e:
+            print(f"Error reading puzzle {i}: {str(e)}")
+            continue
+    
+    # print(f"Number of solvable puzzles: {num_sols}")
+    # print(f"Number of timeouts: {num_timeouts}")
+
+
+
+    
+    # filepath = f"generated_QAs/birds_923.txt"
+    # ground_truth, raw_constraints = read_file(filepath)
+    # birds = deepcopy(ground_truth)
+    # random.shuffle(birds)
+    # solver = PuzzleSolver(birds=birds, puzzle_constraints= raw_constraints)
+    # solver.parse_constraints()
+    # final_arrangement = solver.solve()
+    # if not final_arrangement:
+    #     print("No solution found.")
+    # else:
+    #     print("Solution found.")
+
+
+def solve_puzzle(ground_truth, raw_constraints):
+    timeout_seconds = 30
+    birds = deepcopy(ground_truth)
+    random.shuffle(birds)
+    solver = PuzzleSolver(birds=birds, puzzle_constraints=raw_constraints)
+    solver.parse_constraints()
+    start_time = time.time()
+    final_arrangement = solve_with_timeout(solver, timeout_seconds)
+    solve_time = time.time() - start_time
+    if final_arrangement:
+        return solver.steps
+    else:
+        return None
+    
+
+
+if __name__ == "__main__":
+    solve_all_puzzles(1000)

--- a/examples/data_preprocess/puzzle_gen.py
+++ b/examples/data_preprocess/puzzle_gen.py
@@ -1,0 +1,316 @@
+import random
+from itertools import permutations
+from typing import List, Set, Dict, Tuple, Optional
+from dataclasses import dataclass
+import os
+from datetime import datetime
+import random
+import gen_proof
+import csv
+import argparse
+import json
+
+@dataclass
+class Constraint:
+    text: str              # Human-readable constraint
+    object1: Optional[int]   # First object's encoded value (if applicable)
+    object2: Optional[int]   # Second object's encoded value (if applicable)
+    constraint_type: str   # Type of mathematical constraint
+    value: Optional[int]   # Additional value needed for constraint (e.g., number of birds between)
+    
+    def evaluate(self, positions: List[int]) -> bool:
+        """Evaluate if the constraint is satisfied for given positions."""
+        if self.constraint_type == "left_of":
+            return positions.index(self.object1) < positions.index(self.object2)
+        elif self.constraint_type == "right_of":
+            return positions.index(self.object1) > positions.index(self.object2)
+        elif self.constraint_type == "adjacent_left":
+            return positions.index(self.object1) + 1 == positions.index(self.object2)
+        elif self.constraint_type == "adjacent_right":
+            return positions.index(self.object1) - 1 == positions.index(self.object2)
+        elif self.constraint_type == "birds_between":
+            return abs(positions.index(self.object1) - positions.index(self.object2)) - 1 == self.value
+        elif self.constraint_type == "absolute_position_left":
+            return positions.index(self.object1) == self.value - 1
+        elif self.constraint_type == "absolute_position_right":
+            return positions.index(self.object1) == len(positions) - self.value
+        return False
+
+class BirdPuzzleGenerator:
+    def __init__(self, objects: List[str]):
+        self.birds = objects
+        self.num_positions = len(objects)
+        # Encode birds as integers (0 to n-1)
+        self.bird_encoding = {bird: i for i, bird in enumerate(objects)}
+        self.bird_decoding = {i: bird for i, bird in enumerate(objects)}
+        
+        # Generate ground truth
+        self.ground_truth_birds = list(objects)
+        random.shuffle(self.ground_truth_birds)
+        # Store encoded ground truth positions
+        self.ground_truth = [self.bird_encoding[bird] for bird in self.ground_truth_birds]
+        
+    def generate_all_constraints(self) -> List[Constraint]:
+        """Generate all possible true constraints based on ground truth."""
+        absolute_constraints = []
+        relative_constraints = []
+        # Generate all types of constraints
+        for i in range(self.num_positions):
+            bird1_code = self.ground_truth[i]
+            bird1_name = self.bird_decoding[bird1_code]
+            
+            # Absolute position constraints
+            pos_suffix = lambda n: 'th' if 11 <= n % 100 <= 13 else {1: 'st', 2: 'nd', 3: 'rd'}.get(n % 10, 'th')
+            left_pos = i + 1
+            right_pos = self.num_positions - i
+            
+            absolute_constraints.append(Constraint(
+                text=f"The {bird1_name} is the {left_pos}{pos_suffix(left_pos)} from the left",
+                object1=bird1_code,
+                object2=None,
+                constraint_type="absolute_position_left",
+                value=left_pos
+            ))
+            
+            absolute_constraints.append(Constraint(
+                text=f"The {bird1_name} is the {right_pos}{pos_suffix(right_pos)} from the right",
+                object1=bird1_code,
+                object2=None,
+                constraint_type="absolute_position_right",
+                value=right_pos
+            ))
+            
+            # Relative position constraints
+            for j in range(i + 1, self.num_positions):
+                bird2_code = self.ground_truth[j]
+                bird2_name = self.bird_decoding[bird2_code]
+                
+                # Left/Right relationships
+                relative_constraints.append(Constraint(
+                    text=f"The {bird1_name} is to the left of the {bird2_name}",
+                    object1=bird1_code,
+                    object2=bird2_code,
+                    constraint_type="left_of",
+                    value=None
+                ))
+                
+                relative_constraints.append(Constraint(
+                    text=f"The {bird2_name} is to the right of the {bird1_name}",
+                    object1=bird2_code,
+                    object2=bird1_code,
+                    constraint_type="right_of",
+                    value=None
+                ))
+                
+                # Birds between
+                birds_between = j - i - 1
+                if birds_between > 0:
+                    plural = "s" if birds_between > 1 else ""
+                    relative_constraints.append(Constraint(
+                        text=f"There {['is', 'are'][birds_between > 1]} {birds_between} bird{plural} between the {bird1_name} and the {bird2_name}",
+                        object1=bird1_code,
+                        object2=bird2_code,
+                        constraint_type="birds_between",
+                        value=birds_between
+                    ))
+                
+                # Adjacent relationships
+                if birds_between == 0:
+                    relative_constraints.append(Constraint(
+                        text=f"The {bird1_name} is immediately to the left of the {bird2_name}",
+                        object1=bird1_code,
+                        object2=bird2_code,
+                        constraint_type="adjacent_left",
+                        value=None
+                    ))
+                    
+                    relative_constraints.append(Constraint(
+                        text=f"The {bird2_name} is immediately to the right of the {bird1_name}",
+                        object1=bird2_code,
+                        object2=bird1_code,
+                        constraint_type="adjacent_right",
+                        value=None
+                    ))
+        
+        return absolute_constraints, relative_constraints
+
+    def verify_arrangement(self, constraints: List[Constraint], test_arrangement: List[int]) -> bool:
+        """Verify if a given arrangement satisfies all constraints using mathematical evaluation."""
+        return all(constraint.evaluate(test_arrangement) for constraint in constraints)
+
+    def find_minimal_constraints(self) -> List[Constraint]:
+        """Find a minimal set of constraints that uniquely determines the ground truth.
+        Uses incremental constraint addition until solution space reduces to one arrangement."""
+        absolute_constraints, relative_constraints = self.generate_all_constraints()
+        # Shuffle constraints to randomize selection order
+        abs_constraints = list(absolute_constraints)
+        random.shuffle(abs_constraints)
+        rel_constraints = list(relative_constraints)
+        random.shuffle(rel_constraints)
+        
+        selected_constraints = []
+
+        # num_absolute = random.randint(0, int(self.num_positions*0.4))
+        num_absolute = 0
+        while len(selected_constraints) < num_absolute:
+            selected_constraints.append(abs_constraints.pop(0))
+        
+        while rel_constraints and len(selected_constraints) < len(rel_constraints):
+            # Take the next constraint
+            current_constraint = rel_constraints.pop(0)
+            selected_constraints.append(current_constraint)
+            
+            # Find all valid arrangements given current constraints
+            valid_arrangements = []
+            for perm in permutations(range(self.num_positions)):
+                if self.verify_arrangement(selected_constraints, list(perm)):
+                    valid_arrangements.append(list(perm))
+                    # if len(valid_arrangements) > 1:
+                    #     break
+            
+            # If we've found a unique solution matching ground truth
+            if len(valid_arrangements) == 1:
+                if valid_arrangements[0] == self.ground_truth:
+                    print("Found minimal constraint set!")
+                    return selected_constraints
+                else:
+                    # Our constraints led to a wrong unique solution
+                    print("Warning: Constraints led to incorrect unique solution.")
+                    # Remove the last constraint and try a different one
+                    selected_constraints.pop()
+                    continue
+            
+            # If we have no valid arrangements, the last constraint was incompatible
+            if len(valid_arrangements) == 0:
+                print("Warning: No valid arrangements with these constraints.")
+                # Remove the incompatible constraint and continue
+                selected_constraints.pop()
+                continue
+        
+        print("Warning: Could not find a minimal constraint set.")
+        return selected_constraints
+
+    def generate_puzzle(self) -> Tuple[List[Constraint], List[List[int]]]:
+        """Generate a puzzle with constraints and wrong arrangements."""
+        constraints = self.find_minimal_constraints()
+        return constraints
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate ordering puzzles for evaluating reasoning in LLMs")
+    parser.add_argument("--num_puzzles", type=int, default=10000, help="Number of puzzles to generate")
+    parser.add_argument("--output_dir", type=str, default="datasets", help="Output directory for generated puzzles")
+    parser.add_argument("--output_file", type=str, default="bird_puzzles.json", help="Output filename for generated puzzles")
+    parser.add_argument("--test", type=bool, default=False, help="Generate set without solution traces")
+    args = parser.parse_args()
+
+    birds = ["hawk", "hummingbird", "quail", "owl", "crow", "robin", "cardinal", "sparrow", "bluejay", "pigeon", 
+            "eagle", "falcon", "finch", "woodpecker", "duck", "goose", "swan", "seagull", "pelican", "flamingo", "parrot", 
+            "macaw", "peacock", "penguin", "ostrich", "emu", "vulture", "raven", "magpie", "starling", "warbler", "chickadee", 
+            "swallow", "martin", "oriole", "dove", "pheasant", "turkey", "toucan", "kingfisher", "heron", "egret", "stork", 
+            "kiwi", "albatross", "condor"]
+
+    mammals = ["lion", "tiger", "bear", "wolf", "fox", "deer", "elephant", "giraffe", "zebra", "rhino", 
+            "hippo", "monkey", "gorilla", "chimpanzee", "kangaroo", "koala", "panda", "raccoon", "squirrel", 
+            "rabbit", "mouse", "rat", "bat", "whale", "dolphin", "seal", "walrus", "otter", "beaver", 
+            "hedgehog", "armadillo", "sloth", "opossum", "weasel", "badger", "skunk", "moose", "bison", 
+            "camel", "llama", "alpaca", "horse", "donkey", "cow", "goat", "sheep", "pig"]
+    
+    fruits = ["apple", "orange", "banana", "grape", "strawberry", "blueberry", "raspberry", "blackberry", 
+            "watermelon", "cantaloupe", "honeydew", "pineapple", "mango", "papaya", "kiwi", "pear", 
+            "peach", "plum", "apricot", "cherry", "lemon", "lime", "grapefruit", "coconut", "fig", 
+            "date", "guava", "passion fruit", "pomegranate", "dragonfruit", "lychee", "persimmon", 
+            "avocado", "starfruit", "durian", "jackfruit", "nectarine", "tangerine", "clementine"]
+
+    vehicles = ["car", "truck", "bus", "motorcycle", "scooter", "bicycle", "train", "tram", "subway", 
+                "helicopter", "airplane", "jet", "rocket", "spaceship", "submarine", "ship", "yacht", 
+                "sailboat", "speedboat", "canoe", "kayak", "van", "ambulance", "firetruck", "tractor", 
+                "bulldozer", "crane", "forklift", "excavator", "tank", "snowmobile", "golf cart", 
+                "limousine", "taxi", "trolley", "rickshaw", "hovercraft", "blimp", "hot air balloon"]
+    
+    instruments = ["guitar", "piano", "violin", "cello", "bass", "harp", "flute", "clarinet", "saxophone", 
+                "trumpet", "trombone", "tuba", "oboe", "bassoon", "piccolo", "recorder", 
+                "harmonica", "accordion", "banjo", "mandolin", "ukulele", "drums", "bongos", "congas", 
+                "tambourine", "xylophone", "marimba", "vibraphone", "glockenspiel", "triangle", "cymbals", 
+                "bagpipes", "sitar", "shamisen", "erhu", "theremin", "synthesizer", "organ", "harpsichord"]
+
+    gemstones = ["diamond", "ruby", "emerald", "sapphire", "amethyst", "topaz", "opal", "pearl", "jade", 
+                "garnet", "aquamarine", "turquoise", "moonstone", "amber", "onyx", "quartz", "citrine", 
+                "peridot", "tanzanite", "agate", "alexandrite", "beryl", "malachite", "obsidian", "jasper", 
+                "zircon", "spinel", "sunstone", "tourmaline", "lapis lazuli", "hematite", "pyrite", 
+                "rhodochrosite", "fluorite", "calcite", "azurite", "chrysoberyl", "sodalite", "carnelian"]
+
+    people = ["Emma", "Liam", "Wei", "Priya", "Mohammed", "Sofia", "Jamal", "Yuki", 
+                "Isabella", "Raj", "Noah", "Ling", "Santiago", "Amara", "Daniel", 
+                "Fatima", "Chen", "Miguel", "Aisha", "Sanjay", "Harper", "Takashi", 
+                "Kwame", "Elena", "Omar", "Zoe", "Hiroshi", "Nia", "Gabriel", "Jin", 
+                "Maya", "Mateo", "Layla", "Arjun", "Clara", "Ahmed", "Mei", "Luis", 
+                "Imani", "Alejandro", "Divya", "Kenji", "Chioma", "Paulo", "Ananya", 
+                "Hassan", "Valentina", "Kofi", "Sakura", "Amir"]
+
+    random.seed(42)
+    num_puzzles = args.num_puzzles
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+
+    # Create the "generated_QAs" folder at the same level as the Python file if it doesn't exist
+    output_folder = os.path.join(base_dir, args.output_dir)
+    if not os.path.exists(output_folder):
+        os.makedirs(output_folder)
+
+    output_file = os.path.join(output_folder, args.output_file)
+    
+    if args.test:
+        output_file_test = os.path.join(output_folder, args.output_file.replace(".json", "_test.json"))
+    else:
+        output_file_test = os.path.join(output_folder, args.output_file.replace(".json", "_unsolved.json"))
+    
+    puzzles_data = []
+    puzzles_test_data = []
+    object_types = {
+        'birds': birds,
+        'mammals': mammals,
+        'fruits': fruits,
+        'vehicles': vehicles, 
+        'instruments': instruments,
+        'gemstones': gemstones,
+        'people': people
+    }
+    for id in range(num_puzzles):
+        num_objects = random.randint(3, 7)
+        
+        type_name = random.choice(list(object_types.keys()))
+        type_objects = object_types[type_name]
+        curr_birds = random.sample(type_objects, num_objects)
+        birds_str = ", ".join(curr_birds)
+        instruction = f"Solve the following puzzle to determine the order of the {type_name} from left to right. The {type_name} are {birds_str}."
+        generator = BirdPuzzleGenerator(curr_birds)
+        
+        constraints = generator.generate_all_constraints()
+        constraints = generator.generate_puzzle()
+        input = ""
+        input_constraints = []
+        for i, constraint in enumerate(constraints, 1):
+            input_constraints.append(constraint.text)
+            input += f"{i}. {constraint.text}\n"
+        if not args.test:
+            output = gen_proof.solve_puzzle(ground_truth = generator.ground_truth_birds, raw_constraints = input_constraints)
+            if output:
+                output = "\n".join(output)
+                puzzle_data = {'id': id, 'instruction': instruction, 'input': input, 'output': output, 'ground_truth': generator.ground_truth_birds, 'num_objects': num_objects}
+                puzzles_data.append(puzzle_data)
+            else:
+                puzzle_data = {'id': id, 'instruction':instruction, 'input': input, 'ground_truth': generator.ground_truth_birds, 'num_objects': num_objects}
+                puzzles_test_data.append(puzzle_data)
+        else:
+            puzzle_data = {'id': id, 'instruction':instruction, 'input': input, 'ground_truth': generator.ground_truth_birds, 'num_objects': num_objects}
+            puzzles_test_data.append(puzzle_data)
+    if args.test:
+        with open(output_file, 'w') as json_file:
+            json.dump(puzzles_test_data, json_file, indent=2)
+    else:
+        with open(output_file, 'w') as json_file:
+            json.dump(puzzles_data, json_file, indent=2)
+        with open(output_file_test, 'w') as json_file_test:
+            json.dump(puzzles_test_data, json_file_test, indent=2)
+
+# example usage
+# python puzzle_gen.py --num_puzzles 10000 --output_dir data/puzzles_dataset --output_file puzzles_dataset.json  --test True

--- a/examples/data_preprocess/puzzles_dataset.py
+++ b/examples/data_preprocess/puzzles_dataset.py
@@ -1,0 +1,146 @@
+# Copyright 2024
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Preprocess a CSV dataset to parquet format
+"""
+import os
+import datasets
+import argparse
+import re
+from sklearn.model_selection import train_test_split
+
+from transformers import (
+    LlamaForCausalLM,
+    LlamaTokenizer,
+    AutoTokenizer,
+)
+
+PROMPT_DICT = {
+    "prompt_input": (
+        "Below is an instruction that describes a task, paired with an input that provides further context. "
+        "Write a response that appropriately completes the request.\n\n"
+        "### Instruction:\n{instruction}\n\n### Input:\n{input}\n\n### Response:"
+    ),
+    "prompt_no_input": (
+        "Below is an instruction that describes a task. "
+        "Write a response that appropriately completes the request.\n\n"
+        "### Instruction:\n{instruction}\n\n### Response:"
+    ),
+}
+    
+def make_prefix(dp, tokenizer):
+    constraints = dp['input']
+    result = dp['ground_truth']
+    instruction = dp['instruction']
+    
+    prefix = [{"role": "system", "content": "You are a helpful assistant. You first think about the reasoning process in the mind and then provides the user with the answer."},
+                    {"role": "user", "content": f"{instruction}. The constraints are: {constraints}. Think step by step to find the answer. Show your work in <think> </think> tags. And return the final answer in <answer> </answer> tags, for example <answer> ['pigeon', 'sparrow', 'quail'] </answer>."},
+                    {"role": "assistant", "content": "Let me solve this step by step."}]
+    chat_text = tokenizer.apply_chat_template(prefix, tokenize=False)
+    return chat_text
+
+
+def extract_from_ground_truth(text):
+    if isinstance(text, list):
+        return text
+    else:
+        return eval(text)
+
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--json_path', default='data/puzzles_dataset/puzzles_dataset.json', help='Path to json file')
+    parser.add_argument('--local_dir', default='data/puzzles_dataset', help='Local directory to save parquet files')
+    parser.add_argument('--hdfs_dir', default=None, help='HDFS directory (optional)')
+    parser.add_argument('--test_size', type=float, default=0.1, help='Proportion of data for test set')
+    parser.add_argument('--data_source', default='ordering_puzzle_dataset', help='Name of data source')
+    parser.add_argument('--model_name', default='meta-llama/Llama-3.2-1B-Instruct', help='Name of model')
+    args = parser.parse_args()
+    
+    # Load dataset from CSV
+    dataset = datasets.load_dataset('json', data_files=args.json_path)['train']
+    auth_token = os.getenv('HF_TOKEN')
+    tokenizer = AutoTokenizer.from_pretrained(args.model_name, auth_token = auth_token, padding_side = "left", truncation_side='left')
+    tokenizer.pad_token = tokenizer.eos_token
+    tokenizer = AutoTokenizer.from_pretrained(args.model_name, auth_token = auth_token, padding_side = "left", truncation_side='left')
+    # Function to transform data format
+    def make_map_fn(split):
+        def process_fn(example, idx):
+            question = make_prefix(example, tokenizer)
+            num_objects = example['num_objects']
+            final_arrangement = extract_from_ground_truth(example['ground_truth'])
+            return {
+                "data_source": args.data_source,
+                "prompt": [{
+                    "role": "user",
+                    "content": question,
+                }],
+                "ability": "problem_solving",
+                "reward_model": {
+                        "style": "rule",
+                        "ground_truth": final_arrangement
+                    },
+                "extra_info": {
+                    'id': example['id'] if 'id' in example else str(idx),
+                    'raw_instruction': example['instruction'],
+                    'raw_input': example['input'],
+                    'num_objects': num_objects,
+                }
+            }
+        return process_fn
+    
+    # Transform dataset
+    processed_dataset = dataset.map(function=make_map_fn('train'), with_indices=True)
+    
+    # Create train/test split
+    train_indices, test_indices = train_test_split(
+        range(len(processed_dataset)), 
+        test_size=args.test_size, 
+        random_state=42
+    )
+    
+    # Create train and test datasets
+    train_dataset = processed_dataset.select(train_indices)
+    test_dataset = processed_dataset.select(test_indices)
+    
+    # Add split information
+    def add_split_info(example, split_name):
+        example['extra_info']['split'] = split_name
+        return example
+    
+    train_dataset = train_dataset.map(lambda x: add_split_info(x, 'train'))
+    test_dataset = test_dataset.map(lambda x: add_split_info(x, 'test'))
+    
+    # Create directory if it doesn't exist
+    local_dir = os.path.expanduser(args.local_dir)
+    os.makedirs(local_dir, exist_ok=True)
+    
+    # Save to parquet
+    train_dataset.to_parquet(os.path.join(local_dir, 'train.parquet'))
+    test_dataset.to_parquet(os.path.join(local_dir, 'test.parquet'))
+    
+    # Copy to HDFS if specified
+    if args.hdfs_dir is not None:
+        try:
+            from verl.utils.hdfs_io import copy, makedirs
+            makedirs(args.hdfs_dir)
+            copy(src=local_dir, dst=args.hdfs_dir)
+            print(f"Data copied to HDFS: {args.hdfs_dir}")
+        except ImportError:
+            print("HDFS utilities not available. Install verl package for HDFS support.")
+            
+    print(f"Conversion complete. Files saved to {local_dir}")
+    print(f"Train set: {len(train_dataset)} examples")
+    print(f"Test set: {len(test_dataset)} examples")

--- a/verl/utils/reward_score/__init__.py
+++ b/verl/utils/reward_score/__init__.py
@@ -94,6 +94,9 @@ def _default_compute_score(
     elif data_source in ['code']:
         from . import coder1
         res = coder1.compute_score(solution_str, ground_truth, extra_info=extra_info)
+    elif data_source in ['ordering_puzzle_dataset']:
+        from . import puzzles_dataset
+        res = puzzles_dataset.compute_score(solution_str, ground_truth)
     else:
         raise NotImplementedError
 

--- a/verl/utils/reward_score/puzzles_dataset.py
+++ b/verl/utils/reward_score/puzzles_dataset.py
@@ -1,0 +1,165 @@
+import re
+import random
+import ast
+import operator
+
+
+
+def validate_format(response):
+    if not response:
+        return False
+    
+    pattern = r"<think>(.*?)</think>\s*<answer>(.*?)</answer>"
+    match = re.search(pattern, response, re.DOTALL)
+    if match:
+        return True
+    return False
+
+
+def extract_solution(solution_str):
+    """Extract the final arrangement from the solution string."""
+    # Remove everything before the first "Assistant:"
+    if "Assistant:" in solution_str:
+        solution_str = solution_str.split("Assistant:", 1)[1]
+    # for llama chat template
+    elif "<|start_header_id|>assistant<|end_header_id|>" in solution_str:
+        solution_str = solution_str.split("<|start_header_id|>assistant<|end_header_id|>", 1)[1]
+    # qwen chat template
+    elif "<|im_start|>assistant" in solution_str:
+        solution_str = solution_str.split("<|im_start|>assistant", 1)[1]
+    else:
+        return None
+
+    # Find the answer tag content
+    answer_pattern = r'<answer>(.*?)</answer>'
+    match = re.finditer(answer_pattern, solution_str)
+    matches = list(match)
+    
+    if matches:
+        final_answer = matches[-1].group(1).strip()
+        
+        # Use regex to safely extract the bird names without eval
+        bird_pattern = r'\[[\s\'\"]*([^\],]+)[\s\'\"]*(?:,[\s\'\"]*([^\],]+)[\s\'\"]*)*\]'
+        bird_match = re.search(bird_pattern, final_answer)
+        
+        if bird_match:
+            # Extract all bird names from the list
+            bird_list_str = bird_match.group(0)
+            # Extract individual birds, handling different formats
+            birds = re.findall(r'[\'"]?([\w\s]+)[\'"]?', bird_list_str)
+            # Clean up the extracted birds (removing list brackets, quotes, etc.)
+            birds = [bird.lower().strip() for bird in birds if bird.strip() and bird.strip() not in ['[', ']']]
+            return birds
+        else:
+            # If we can't extract using regex, try a safer approach
+            try:
+                # Add quotes around unquoted words to make it valid Python
+                fixed_str = re.sub(r'(\[|\s*,\s*)(\w+)(\s*,|\])', r'\1"\2"\3', final_answer)
+                return eval(fixed_str)
+            except:
+                # Last resort: just return as text
+                return None
+    else:
+        return None
+
+
+def compute_edit_distance(list1, list2):
+    """
+    Calculate edit distance between two lists.
+    Returns the minimum number of operations (insertions, deletions, substitutions)
+    required to transform list1 into list2.
+    """
+    # Create a matrix of size (len(list1)+1) x (len(list2)+1)
+    dp = [[0 for _ in range(len(list2) + 1)] for _ in range(len(list1) + 1)]
+    
+    # Initialize the first row and column
+    for i in range(len(list1) + 1):
+        dp[i][0] = i
+    for j in range(len(list2) + 1):
+        dp[0][j] = j
+    
+    # Fill the matrix
+    for i in range(1, len(list1) + 1):
+        for j in range(1, len(list2) + 1):
+            if list1[i-1] == list2[j-1]:
+                dp[i][j] = dp[i-1][j-1]
+            else:
+                dp[i][j] = 1 + min(dp[i-1][j],      # deletion
+                                    dp[i][j-1],      # insertion
+                                    dp[i-1][j-1])    # substitution
+    
+    return dp[len(list1)][len(list2)]
+
+# granular reward function
+def compute_score(solution_str, ground_truth, method='strict', format_score=0.1, score=1.):
+    """The scoring function for bird puzzles task.
+    
+    Args:
+        solution_str: the solution text
+        ground_truth: dictionary containing target number and available numbers
+        method: the method to extract the solution
+        format_score: the score for correct format but wrong answer
+        score: the score for the correct answer
+    """
+    target = ground_truth.tolist()
+    predicted_arrangement = extract_solution(solution_str=solution_str)
+    do_print = random.randint(1, 64) == 1
+
+    if do_print:
+        print(f"--------------------------------")
+        print(f"Target: {ground_truth}")
+        print(f"Extracted arrangement: {predicted_arrangement}")
+        print(f"Solution string: {solution_str}")
+        print(f"--------------------------------")
+    if predicted_arrangement is None:
+        if do_print:
+            print(f"No final arrangement found")
+        return 0
+    
+    
+    # Validate format is correct
+    if not validate_format(solution_str):
+        if do_print:
+            print(f"Format not followed properly")
+        return format_score
+        
+    # Evaluate equation
+    try:
+        if isinstance(predicted_arrangement, list) and isinstance(target, list):            
+            edit_distance = compute_edit_distance(predicted_arrangement, target)
+            if do_print:
+                print(f"Edit distance: {edit_distance}")
+            max_possible_dist = max(len(predicted_arrangement), len(target))
+
+
+        result = predicted_arrangement == target
+        if result:
+            if do_print:
+                print(f"Correct arrangement")
+            return score
+        else:
+            reward = max(format_score, score*(1.0 - (edit_distance / max_possible_dist)))
+            if do_print:
+                print(f"Wrong/Partially correct arrangement: predicted_arrangement = {predicted_arrangement}, target = {target}")
+                print(f"Edit distance: {edit_distance}/{max_possible_dist}, Reward: {reward:.4f}")
+            return reward
+    except Exception as e:
+        if do_print:
+            print(f"Error evaluating result: {type(e).__name__}: {str(e)}")
+            try:
+                if isinstance(predicted_arrangement, list) and isinstance(target, list):
+                    pred_norm = [str(p).lower().strip() for p in predicted_arrangement]
+                    target_norm = [str(t).lower().strip() for t in target]
+                    print(f"Normalized comparison: {pred_norm == target_norm}")
+            except Exception as e2:
+                print(f"Error during normalization attempt: {str(e2)}")
+        return format_score 
+
+def compute_accuracy(solution_str, ground_truth):
+    target = ground_truth.tolist()
+    predicted_arrangement = extract_solution(solution_str=solution_str)
+    if predicted_arrangement is None:
+        return 0
+    if not validate_format(solution_str):
+        return 0
+    return int(predicted_arrangement == target)


### PR DESCRIPTION
Add ordering puzzles into the RL training pipeline.

Puzzles can be generated by running python puzzle_gen.py --num_puzzles 10000 --output_dir data/puzzles_dataset --output_file puzzles_dataset.json  --test True
and then incorporated into the training pipeline after generating the parquet format files using puzzles_dataset.py in the examples/data_preprocess folder. 
 