### PR TITLE
[Megatron] Dispatch dummy data to TP and PP rank other than 0

### DIFF
--- a/verl/recipe/dapo/src/dapo_ray_trainer.py
+++ b/verl/recipe/dapo/src/dapo_ray_trainer.py
@@ -227,6 +227,8 @@ class RayDAPOTrainer(RayPPOTrainer):
                             batch_keys=["responses", "input_ids", "attention_mask", "position_ids"],
                             non_tensor_batch_keys=["uid"],
                         )
+                        if self.global_steps <= 1:
+                            print(f"removing keys {set(batch.batch.keys()) - set(log_prob_input_batch.batch.keys())} for old logprob.", flush=True)
                         old_log_prob = self.actor_rollout_wg.compute_log_prob(log_prob_input_batch)
                         entropys = old_log_prob.batch["entropys"]
                         response_masks = batch.batch["response_mask"]
@@ -268,6 +270,8 @@ class RayDAPOTrainer(RayPPOTrainer):
                                 batch_keys=["responses", "input_ids", "attention_mask", "position_ids"],
                                 non_tensor_batch_keys=["uid"],
                             )
+                            if self.global_steps <= 1:
+                                print(f"removing keys {set(batch.batch.keys()) - set(ref_log_prob_input_batch.batch.keys())} for ref logprob.", flush=True)
                             if not self.ref_in_actor:
                                 ref_log_prob = self.ref_policy_wg.compute_ref_log_prob(ref_log_prob_input_batch)
                             else:
@@ -304,9 +308,13 @@ class RayDAPOTrainer(RayPPOTrainer):
                     # implement critic warmup
                     if self.config.trainer.critic_warmup <= self.global_steps:
                         # update actor
+                        train_batch_keys = ["responses", "input_ids", "attention_mask", "position_ids", "old_log_probs", "advantages"]
+                        if self.global_steps <= 1:
+                            print(f"removing keys {set(batch.batch.keys()) - set(train_batch_keys)} for training.", flush=True)
+                        train_batch = batch.select(batch_keys=train_batch_keys, non_tensor_batch_keys=set())
                         with _timer("update_actor", timing_raw):
-                            batch.meta_info["multi_turn"] = self.config.actor_rollout_ref.rollout.multi_turn.enable
-                            actor_output = self.actor_rollout_wg.update_actor(batch)
+                            train_batch.meta_info["multi_turn"] = self.config.actor_rollout_ref.rollout.multi_turn.enable
+                            actor_output = self.actor_rollout_wg.update_actor(train_batch)
                         actor_output_metrics = reduce_metrics(actor_output.meta_info["metrics"])
                         metrics.update(actor_output_metrics)
 

--- a/verl/single_controller/base/decorator.py
+++ b/verl/single_controller/base/decorator.py
@@ -502,14 +502,14 @@ def dispatch_megatron_pp_dummy_data_proto(worker_group, *args, **kwargs):
             for arg_idx, arg in enumerate(all_args):
                 if isinstance(arg[rank], (DataProto, DataProtoFuture)):
                     # Get the original DataProto to extract shape information
-                    original_arg = args[arg_idx] if arg_idx < len(args) else None
+                    original_arg = arg[rank]
                     if original_arg is not None and isinstance(original_arg, DataProto):
                         all_args[arg_idx][rank] = _make_dummy_data_proto(original_arg)
 
             # Handle kwargs similarly
             for key, val_list in all_kwargs.items():
                 if isinstance(val_list[rank], (DataProto, DataProtoFuture)):
-                    original_val = kwargs.get(key)
+                    original_val = val_list[rank]
                     if original_val is not None and isinstance(original_val, DataProto):
                         all_kwargs[key][rank] = _make_dummy_data_proto(original_val)
 

--- a/verl/utils/reward_score/math_llm_judge/math_normalize.py
+++ b/verl/utils/reward_score/math_llm_judge/math_normalize.py
@@ -156,7 +156,7 @@ def _strip_string(string):
 
     # remove percentage
     string = string.replace("\\%", "")
-    string = string.replace("\%", "")
+    string = string.replace("\\%", "")
 
     # " 0." equivalent to " ." and "{0." equivalent to "{." Alternatively, add "0" if "." is the start of the string
     string = string.replace(" .", " 0.")

--- a/verl/workers/megatron_workers.py
+++ b/verl/workers/megatron_workers.py
@@ -41,6 +41,7 @@ from verl.utils.megatron_utils import (
     offload_megatron_optimizer,
 )
 from verl.utils.model import load_mcore_dist_weights, load_megatron_gptmodel_weights
+from verl.utils.torch_functional import broadcast_dict_tensor
 from verl.workers.actor.megatron_actor import MegatronPPOActor
 from verl.workers.critic.megatron_critic import MegatronPPOCritic
 from verl.workers.reward_model.megatron.reward_model import MegatronRewardModel
@@ -66,6 +67,17 @@ def set_random_seed(seed):
     # https://github.com/pytorch/pytorch/issues/89492
     # torch.use_deterministic_algorithms(True, warn_only=True)
     # os.environ['CUBLAS_WORKSPACE_CONFIG'] = ':4096:8'
+
+
+def megatron_pp_dummy_output(data: DataProto):
+    from verl.single_controller.base.decorator import _make_dummy_data_proto
+
+    if (
+        mpu.get_pipeline_model_parallel_rank() != mpu.get_pipeline_model_parallel_world_size() - 1   # not the last stage
+        or mpu.get_tensor_model_parallel_rank() != 0    # not the first tensor parallel rank
+    ):
+        return _make_dummy_data_proto(data)
+    return data
 
 
 class ActorRolloutRefWorker(MegatronWorker):
@@ -492,6 +504,9 @@ class ActorRolloutRefWorker(MegatronWorker):
         data.meta_info["use_dynamic_bsz"] = self.config.ref.log_prob_use_dynamic_bsz
         data.meta_info["temperature"] = self.config.rollout.temperature
         data = data.to(torch.cuda.current_device())
+
+        broadcast_dict_tensor(data.batch, src=mpu.get_tensor_model_parallel_src_rank(), group=mpu.get_tensor_model_parallel_group())
+
         # NOTE: this function internally broadcasts the last stage's input and output to all ranks.
         output, _ = self.ref_policy.compute_log_prob(data=data, calculate_entropy=False)
         output = DataProto.from_dict(tensors={"ref_log_prob": output})
@@ -500,7 +515,7 @@ class ActorRolloutRefWorker(MegatronWorker):
             offload_megatron_model_to_cpu(self.ref_module)
             log_gpu_memory_usage("After offload ref params and grad during compute_ref_log_prob", logger=logger)
         torch.cuda.empty_cache()
-        return output
+        return megatron_pp_dummy_output(output)
 
     @register(dispatch_mode=Dispatch.MEGATRON_PP_DUMMY_PROTO)
     @GPUMemoryLogger(role="compute_log_prob", logger=logger)
@@ -515,6 +530,9 @@ class ActorRolloutRefWorker(MegatronWorker):
         data.meta_info["use_dynamic_bsz"] = self.config.rollout.log_prob_use_dynamic_bsz
         data.meta_info["temperature"] = self.config.rollout.temperature
         data = data.to(torch.cuda.current_device())
+
+        broadcast_dict_tensor(data.batch, src=mpu.get_tensor_model_parallel_src_rank(), group=mpu.get_tensor_model_parallel_group())
+
         # NOTE: this function internally broadcasts the last stage's input and output to all ranks.
         output, entropys = self.actor.compute_log_prob(data=data, calculate_entropy=True)
         output = DataProto.from_dict(tensors={"old_log_probs": output, "entropys": entropys}, meta_info={"temperature": self.config.rollout.temperature})
@@ -524,7 +542,7 @@ class ActorRolloutRefWorker(MegatronWorker):
             offload_megatron_model_to_cpu(self.actor_module)
             log_gpu_memory_usage("After offload actor params and grad during compute_log_prob", logger=logger)
         torch.cuda.empty_cache()
-        return output
+        return megatron_pp_dummy_output(output)
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
     def load_checkpoint(self, checkpoint_path, hdfs_path=None, del_local_after_load=True):


### PR DESCRIPTION
Previous verl uses `MEGATRON_COMPUTE_PROTO` to dispatch data, whose logic is: `input[dp_rank][tp_rank][pp_rank] = input[dp_rank]`. In this PR, we introduce `MEGATRON_PP_DUMMY_PROTO` (need a better name...), whose logic is `input[dp_rank][tp_rank][pp_rank] = input[dp_rank] if tp_rank == 0 and pp_rank in (0, -1) else None`, and adds a `broadcast(input, tp_group)`.
For large scale model (tp=8, pp=4 or 8), this significantly reduces the extra data to be sent via Ray (i.e. CPU networking)