### PR TITLE
[worker, config] Integrating verl FP16 fixes

### DIFF
--- a/verl/trainer/config/actor/actor.yaml
+++ b/verl/trainer/config/actor/actor.yaml
@@ -11,6 +11,8 @@ _target_: verl.workers.config.ActorConfig
 # fsdp, fsdp2 or megatron. must be set.
 strategy: ???
 
+dtype: float16
+
 # Split each sample into sub-batches of this size for PPO
 ppo_mini_batch_size: 256
 

--- a/verl/trainer/config/actor/actor.yaml
+++ b/verl/trainer/config/actor/actor.yaml
@@ -11,7 +11,7 @@ _target_: verl.workers.config.ActorConfig
 # fsdp, fsdp2 or megatron. must be set.
 strategy: ???
 
-dtype: float16
+dtype: bfloat16
 
 # Split each sample into sub-batches of this size for PPO
 ppo_mini_batch_size: 256

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -26,7 +26,7 @@ response_length: ${oc.select:data.max_response_length,512}
 
 # for vllm rollout
 # Rollout model parameters type. Align with actor model's FSDP/Megatron type.
-dtype: bfloat16
+dtype: float16
 
 # Fraction of GPU memory used by vLLM/SGLang for KV cache.
 gpu_memory_utilization: 0.5

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -26,7 +26,7 @@ response_length: ${oc.select:data.max_response_length,512}
 
 # for vllm rollout
 # Rollout model parameters type. Align with actor model's FSDP/Megatron type.
-dtype: float16
+dtype: bfloat16
 
 # Fraction of GPU memory used by vLLM/SGLang for KV cache.
 gpu_memory_utilization: 0.5

--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -86,6 +86,12 @@ class DataParallelPPOActor(BasePPOActor):
             else entropy_from_logits
         )
         self.device_name = get_device_name()
+        assert self.config.dtype in ["float16", "bfloat16", "float32"]
+        if self.config.dtype == "float16":
+            from torch.distributed.fsdp.sharded_grad_scaler import ShardedGradScaler
+            self.scaler = ShardedGradScaler(growth_interval=400)
+        else:
+            self.scaler = None
 
     def _forward_micro_batch(
         self, micro_batch, temperature, calculate_entropy=False
@@ -107,7 +113,9 @@ class DataParallelPPOActor(BasePPOActor):
                         [inputs[key] for inputs in micro_batch["multi_modal_inputs"]], dim=0
                     )
 
-        with torch.autocast(device_type=self.device_name, dtype=torch.bfloat16):
+        from verl.utils.torch_dtypes import PrecisionType
+        torch_dtype = PrecisionType.to_dtype(self.config.dtype)
+        with torch.autocast(device_type=self.device_name, dtype=torch_dtype):
             input_ids = micro_batch["input_ids"]
             batch_size, seqlen = input_ids.shape
             attention_mask = micro_batch["attention_mask"]
@@ -282,6 +290,8 @@ class DataParallelPPOActor(BasePPOActor):
     def _optimizer_step(self):
         assert self.config.grad_clip is not None
 
+        if self.scaler is not None:
+            self.scaler.unscale_(self.actor_optimizer)
         if isinstance(self.actor_module, FSDP):
             grad_norm = self.actor_module.clip_grad_norm_(max_norm=self.config.grad_clip)
         elif isinstance(self.actor_module, FSDPModule):
@@ -289,12 +299,17 @@ class DataParallelPPOActor(BasePPOActor):
         else:
             grad_norm = torch.nn.utils.clip_grad_norm_(self.actor_module.parameters(), max_norm=self.config.grad_clip)
 
-        # if grad_norm is not finite, skip the update
-        if not torch.isfinite(grad_norm):
-            print(f"WARN: rank {torch.distributed.get_rank()} grad_norm is not finite: {grad_norm}")
-            self.actor_optimizer.zero_grad()
+        if self.scaler is not None:
+            self.scaler.step(self.actor_optimizer)
+            self.scaler.update()
         else:
-            self.actor_optimizer.step()
+            # if grad_norm is not finite, skip the update
+            if not torch.isfinite(grad_norm):
+                print(f"WARN: rand {torch.distributed.get_rank()}: grad_norm is not finite: {grad_norm}")
+                self.actor_optimizer.zero_grad()
+            else:
+                self.actor_optimizer.step()
+        
         return grad_norm
 
     @GPUMemoryLogger(role="dp actor", logger=logger)
@@ -480,7 +495,10 @@ class DataParallelPPOActor(BasePPOActor):
                         loss = policy_loss * loss_scale_factor
                     else:
                         loss = policy_loss * loss_scale_factor
-                    loss.backward()
+                    if self.scaler is not None:
+                        self.scaler.scale(loss).backward()
+                    else:
+                        loss.backward()
 
                     micro_batch_metrics.update(
                         {

--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -114,7 +114,7 @@ class DataParallelPPOActor(BasePPOActor):
                     )
 
         from verl.utils.torch_dtypes import PrecisionType
-        torch_dtype = PrecisionType.to_dtype(self.config.dtype)
+        torch_dtype = PrecisionType.to_dtype(self.config.get("dtype", "bfloat16"))
         with torch.autocast(device_type=self.device_name, dtype=torch_dtype):
             input_ids = micro_batch["input_ids"]
             batch_size, seqlen = input_ids.shape

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -305,9 +305,10 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
             else:
                 self.tokenizer.chat_template = self.config.model.custom_chat_template
 
+        vllm_dtype = PrecisionType.to_dtype(self.config.rollout.dtype)
         torch_dtype = fsdp_config.get("model_dtype", None)
         if torch_dtype is None:
-            torch_dtype = torch.float32 if self._is_actor else torch.bfloat16
+            torch_dtype = torch.float32 if self._is_actor else vllm_dtype
         else:
             torch_dtype = PrecisionType.to_dtype(torch_dtype)
 
@@ -437,7 +438,7 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
             reduce_dtype = PrecisionType.to_dtype(mixed_precision_config.get("reduce_dtype", "fp32"))
             buffer_dtype = PrecisionType.to_dtype(mixed_precision_config.get("buffer_dtype", "fp32"))
         else:
-            param_dtype = torch.bfloat16
+            param_dtype = PrecisionType.to_dtype(self.config.actor.get("dtype", "float16"))
             reduce_dtype = torch.float32
             buffer_dtype = torch.float32
 

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -305,7 +305,7 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
             else:
                 self.tokenizer.chat_template = self.config.model.custom_chat_template
 
-        vllm_dtype = PrecisionType.to_dtype(self.config.rollout.dtype)
+        vllm_dtype = PrecisionType.to_dtype(self.config.rollout.get("dtype", "bfloat16"))
         torch_dtype = fsdp_config.get("model_dtype", None)
         if torch_dtype is None:
             torch_dtype = torch.float32 if self._is_actor else vllm_dtype
@@ -438,7 +438,7 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
             reduce_dtype = PrecisionType.to_dtype(mixed_precision_config.get("reduce_dtype", "fp32"))
             buffer_dtype = PrecisionType.to_dtype(mixed_precision_config.get("buffer_dtype", "fp32"))
         else:
-            param_dtype = PrecisionType.to_dtype(self.config.actor.get("dtype", "float16"))
+            param_dtype = PrecisionType.to_dtype(self.config.actor.get("dtype", "bfloat16"))
             reduce_dtype = torch.float32
             buffer_dtype = torch.float32
 


### PR DESCRIPTION
### What does this PR do?

This PR integrates the updates to verl that allow for FP16 training and inference, following the guidance provided by the authors of `Defeating the Training-Inference Mismatch via FP16` [https://arxiv.org/abs/2510.26788] and shared in this [git diff](https://github.com/sail-sg/Precision-RL/blob/main/verl_fp16.patch)

### Checklist Before Starting

- [X] Search for similar PRs. Paste at least one query link here: ...
- [X] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

...Ongoing infra tests with FlashRL integration...

### API and Usage Example

The only change to API is when setting up the verl launch configuration we now have the option to choose dtype/precision for both the rollout and actor ref configs via:

```python
actor_rollout_ref.actor.dtype=float16
actor_rollout_ref.rollout.dtype=float16
```
